### PR TITLE
Include WWW-Authenticate header in the 401 response

### DIFF
--- a/src/Cimpress.Auth0.Server/AuthenticationExtensions.cs
+++ b/src/Cimpress.Auth0.Server/AuthenticationExtensions.cs
@@ -115,6 +115,7 @@ namespace Cimpress.Auth0.Server
             {
                 Audience = settings.ClientId,
                 Authority = $"https://{settings.Domain}",
+                Challenge = $"Bearer realm=\"{settings.Domain}\", scope=\"client_id={settings.ClientId} service=\"",
                 Events = new JwtBearerEvents
                 {
                     OnAuthenticationFailed = context =>


### PR DESCRIPTION
Added Challenge parameter to the JwtBearerOptions to include a www-authenticate header with the client id and realm in the 401 response.