### PR TITLE
Log the sub instead of the name

### DIFF
--- a/src/Cimpress.Auth0.Server/AuthenticationExtensions.cs
+++ b/src/Cimpress.Auth0.Server/AuthenticationExtensions.cs
@@ -136,7 +136,8 @@ namespace Cimpress.Auth0.Server
                     OnTokenValidated = async context =>
                     {
                         var claimsIdentity = context.Ticket.Principal.Identity as ClaimsIdentity;
-                        logger.LogInformation($"{claimsIdentity?.Name} authenticated using bearer authentication.");
+                        var sub = claimsIdentity?.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+                        logger.LogInformation($"'{sub}' authenticated using bearer authentication.", sub);
 
                         await onTokenValidated(claimsIdentity);
                     }


### PR DESCRIPTION
The sub is always provided, but the name can be null/empty.