### PR TITLE
Add password realm authentication

### DIFF
--- a/src/Cimpress.Auth0.Client/Auth0ClientSettings.cs
+++ b/src/Cimpress.Auth0.Client/Auth0ClientSettings.cs
@@ -64,6 +64,22 @@ namespace Cimpress.Auth0.Client
         /// The audience domain.
         /// </value>
         public string Auth0Audience { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the realm.
+        /// </summary>
+        /// <value>
+        /// The realm used for token authentication.
+        /// </value>
+        public string Auth0Realm { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the grant type.
+        /// </summary>
+        /// <value>
+        /// The grant type used for token authentication.
+        /// </value>
+        public string Auth0GrantType { get; set; }
 
         /// <summary>
         /// Gets or sets the auth0 refresh token.

--- a/src/Cimpress.Auth0.Client/PasswordRealmTokenProvider.cs
+++ b/src/Cimpress.Auth0.Client/PasswordRealmTokenProvider.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Threading;
+using System.Threading.Tasks;
+using Cimpress.Auth0.Client.Proxies;
+using Microsoft.Extensions.Logging;
+
+namespace Cimpress.Auth0.Client
+{
+    public class PasswordRealmTokenProvider : IAuth0TokenProvider
+    {
+        private readonly IAutoScheduler autoScheduler;
+        private readonly Auth0ClientSettings currentSettings;
+        private readonly SemaphoreSlim syncObject = new SemaphoreSlim(1);
+        private readonly IAuthenticationApiClient authenticationApiClient;
+        private readonly ILogger logger;
+
+        public PasswordRealmTokenProvider(ILoggerFactory loggerFactory, Auth0ClientSettings currentSettings, IAuthenticationApiClient authenticationApiClient = null,
+            IAutoScheduler autoScheduler = null)
+        {
+            logger = loggerFactory.CreateLogger<PasswordRealmTokenProvider>();
+            this.authenticationApiClient = authenticationApiClient ?? new AuthenticationApiClient();
+            this.autoScheduler = autoScheduler ?? new AutoScheduler(loggerFactory, this);
+            this.currentSettings = currentSettings;
+            this.currentSettings.Auth0Realm = currentSettings.Auth0Realm ?? "default";
+            this.currentSettings.Auth0GrantType = currentSettings.Auth0GrantType ?? "http://auth0.com/oauth/grant-type/password-realm";
+        }
+
+        public void ScheduleAutoRefresh(Auth0ClientSettings auth0ClientSettings)
+        {
+            autoScheduler.ScheduleRefresh(auth0ClientSettings);
+        }
+
+        public async Task AddOrUpdateClientAsync(Auth0ClientSettings settings, bool forceRefresh = false)
+        {
+            await UpdateAuthHeaderAsync(null, forceRefresh);
+        }
+
+        public async Task AddOrUpdateClientAsync(HttpResponseMessage response, bool forceRefresh = false)
+        {
+            await UpdateAuthHeaderAsync(null, forceRefresh);
+        }
+
+        public async Task AddOrUpdateClientAsync(string clientId, bool forceRefresh = false)
+        {
+            await UpdateAuthHeaderAsync(null, forceRefresh);
+        }
+
+        public async Task<AuthenticationHeaderValue> GetAuthHeaderForClientAsync(string clientId, bool forceRefresh = false)
+        {
+            if (currentSettings.Auth0HeaderValue == null || forceRefresh)
+            {
+                await UpdateAuthHeaderAsync(null, forceRefresh);
+            }
+            return currentSettings.Auth0HeaderValue;
+        }
+
+        public async Task<AuthenticationHeaderValue> GetAuthHeaderForClientAsync(HttpResponseMessage response, bool forceRefresh = false, string clientId = "")
+        {
+            return await GetAuthHeaderForClientAsync(null, forceRefresh);
+        }
+
+        public async Task<AuthenticationHeaderValue> GetAuthHeaderForDomainAsync(string host, bool forceRefresh = false)
+        {
+            return await GetAuthHeaderForClientAsync(null, forceRefresh);
+        }
+
+        public void CacheAuthSettings(Auth0ClientSettings settings)
+        {
+            currentSettings.LastRefresh = settings.LastRefresh;
+            currentSettings.Auth0HeaderValue = settings.Auth0HeaderValue;
+        }
+
+        public async Task UpdateAuthHeaderAsync(string clientId, bool forceRefresh)
+        {
+            if (await syncObject.WaitAsync(10000))
+            {
+                try
+                {
+                    // Only update if really needed. 
+                    // Especially when multiple tasks are invoked at the same time we only need to update once.
+                    // Testing for a valid token happens within GetAuthHeaderForClient but outside of the locked section.
+                    // Therefore it might happen that the token was already updated once entering the locked section.
+                    if (currentSettings.Auth0HeaderValue != null && currentSettings.LastRefresh > DateTimeOffset.Now.AddSeconds(-5) && !forceRefresh)
+                    {
+                        return;
+                    }
+
+                    var request = new PasswordRealmAuthenticationRequestDto
+                    {
+                        ClientId = currentSettings.Auth0ClientId,
+                        Audience = currentSettings.Auth0Audience,
+                        GrantType = currentSettings.Auth0GrantType,
+                        Password = currentSettings.Auth0Password,
+                        Username = currentSettings.Auth0Username,
+                        Realm = currentSettings.Auth0Realm
+                    };
+
+                    // authenticate with auth0
+                    var authToken = await authenticationApiClient.PasswordRealmAuthenticateAsync(request, currentSettings.Auth0ServerUrl);
+
+                    // set the authorization header
+                    currentSettings.Auth0HeaderValue = new AuthenticationHeaderValue("Bearer", authToken.AccessToken);
+                    currentSettings.LastRefresh = DateTimeOffset.Now;
+                    logger.LogInformation($"Successfully authenticated with the service client id {currentSettings.Auth0ClientId} with client secret.");
+
+                    ScheduleAutoRefresh(currentSettings);
+                }
+                catch (Exception ex)
+                {
+                    // any exceptions during authentication are logged here
+                    logger.LogError($"Error authenticating with service: {currentSettings.Auth0ClientId} using user {currentSettings.Auth0Username}.", ex);
+                }
+                finally
+                {
+                    syncObject.Release();
+                }
+            }
+            else
+            {
+                logger.LogWarning("Auth0TokenProvider could not get lock for retrieving an authentication token.");
+            }
+        }
+    }
+}

--- a/src/Cimpress.Auth0.Client/Proxies/AuthenticationApiClient.cs
+++ b/src/Cimpress.Auth0.Client/Proxies/AuthenticationApiClient.cs
@@ -46,6 +46,11 @@ namespace Cimpress.Auth0.Client.Proxies
             return PostAsync<AuthenticationResponseDto>(auth0Domain + (auth0Domain.EndsWith("/") ? "" : "/") + "oauth/ro", request);
         }
 
+        public Task<AuthenticationResponseDto> PasswordRealmAuthenticateAsync(PasswordRealmAuthenticationRequestDto request, string auth0Domain)
+        {
+            return PostAsync<AuthenticationResponseDto>(auth0Domain + (auth0Domain.EndsWith("/") ? "" : "/") + "oauth/token", request);
+        }
+
         /// <summary>
         /// Given an existing token, this endpoint will generate a new token signed with the target client secret. This is used to flow the identity of the user from the application to an API or across different APIs that are protected with different secrets.
         /// </summary>

--- a/src/Cimpress.Auth0.Client/Proxies/IAuthenticationApiClient.cs
+++ b/src/Cimpress.Auth0.Client/Proxies/IAuthenticationApiClient.cs
@@ -19,6 +19,14 @@ namespace Cimpress.Auth0.Client.Proxies
         /// <param name="auth0Domain">The Auth0 domain to which to target the request to.</param>
         /// <returns>A <see cref="AuthenticationResponseDto" /> with the access token.</returns>
         Task<AuthenticationResponseDto> TokenAuthenticateAsync(TokenAuthenticationRequestDto request, string auth0Domain);
+        
+        /// <summary>
+        /// Given an <see cref="PasswordRealmAuthenticationRequestDto" />, it will do the authentication on the provider and return a <see cref="AuthenticationResponseDto" />
+        /// </summary>
+        /// <param name="request">The authentication request details containing information regarding the connection, user credentials etc.</param>
+        /// <param name="auth0Domain">The Auth0 domain to which to target the request to.</param>
+        /// <returns>A <see cref="AuthenticationResponseDto" /> with the access token.</returns>
+        Task<AuthenticationResponseDto> PasswordRealmAuthenticateAsync(PasswordRealmAuthenticationRequestDto request, string auth0Domain);
 
         /// <summary>
         /// Given an existing token, this endpoint will generate a new token signed with the target client secret. This is used to flow the identity of the user from the application to an API or across different APIs that are protected with different secrets.

--- a/src/Cimpress.Auth0.Client/Proxies/PasswordRealmAuthenticationRequestDto.cs
+++ b/src/Cimpress.Auth0.Client/Proxies/PasswordRealmAuthenticationRequestDto.cs
@@ -1,0 +1,49 @@
+using Newtonsoft.Json;
+
+namespace Cimpress.Auth0.Client.Proxies
+{
+    /// <summary>
+    /// Represents a request to authenticate with a connection.
+    /// </summary>
+    /// <remarks>
+    /// This has been copied and slightly adapterd from https://github.com/auth0/auth0.net since it doesn't yet support netcore.
+    /// </remarks>
+    public class PasswordRealmAuthenticationRequestDto
+    {
+        /// <summary>
+        /// Gets or sets the client (app) identifier.
+        /// </summary>
+        [JsonProperty("client_id")]
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the client (app) secret.
+        /// </summary>
+        [JsonProperty("realm")]
+        public string Realm { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the username.
+        /// </summary>
+        [JsonProperty("username")]
+        public string Username { get; set; }
+        
+        /// <summary>
+        /// Gets or sets the username.
+        /// </summary>
+        [JsonProperty("password")]
+        public string Password { get; set; }
+
+        /// <summary>
+        /// Gets or sets the grant type requested.
+        /// </summary>
+        [JsonProperty("grant_type")]
+        public string GrantType { get; set; }
+
+        /// <summary>
+        /// Gets or sets the audience.
+        /// </summary>
+        [JsonProperty("audience")]
+        public string Audience { get; set; }
+    }
+}


### PR DESCRIPTION
Adding a password-realm authentication with a fixed client ID for all applications.

This will make it easy for users without a clientId/clientSecret to get an RS256 token with a specified audience set.

Usage is as follows:

```csharp
            Auth0ClientSettings clientSettings = new Auth0ClientSettings
            {
                Auth0ServerUrl = "https://<subdomain>.auth0.com/",
                Auth0Audience = "<your audience>",
                Auth0ClientId = "<generic client>",
                Auth0GrantType = "http://auth0.com/oauth/grant-type/password-realm",
                Auth0Realm = "default",
                Auth0Username = username,
                Auth0Password = password
            };
            IAuth0TokenProvider tokenProvider = new PasswordRealmTokenProvider(loggerFactory, clientSettings);
            var handler = new AuthHandler(loggerFactory.CreateLogger<MyClass>(), tokenProvider);
            var client = new HttpClient(handler);
```